### PR TITLE
Restore `io::ErrorKind::Unsupported`.

### DIFF
--- a/src/io/error.rs
+++ b/src/io/error.rs
@@ -155,6 +155,10 @@ pub enum ErrorKind {
     /// Unsupported I/O error
     Unsupported,
 
+    /// An operation could not be completed, because it failed to allocate
+    /// enough memory.
+    OutOfMemory,
+
     /// Any I/O error from the standard library that's not part of this list.
     ///
     /// Errors that are `Uncategorized` now may move to a different or a new
@@ -186,6 +190,7 @@ impl ErrorKind {
             ErrorKind::Other => "other os error",
             ErrorKind::UnexpectedEof => "unexpected end of file",
             ErrorKind::Unsupported => "unsupported I/O error",
+            ErrorKind::OutOfMemory => "out of memory",
             ErrorKind::Uncategorized => "uncategorized",
         }
     }
@@ -227,6 +232,7 @@ impl From<std::io::ErrorKind> for ErrorKind {
             std::io::ErrorKind::Other => ErrorKind::Other,
             std::io::ErrorKind::UnexpectedEof => ErrorKind::UnexpectedEof,
             std::io::ErrorKind::Unsupported => ErrorKind::Unsupported,
+            std::io::ErrorKind::OutOfMemory => ErrorKind::OutOfMemory,
             _ => ErrorKind::Uncategorized,
         }
     }

--- a/src/io/error.rs
+++ b/src/io/error.rs
@@ -154,6 +154,14 @@ pub enum ErrorKind {
 
     /// Unsupported I/O error
     Unsupported,
+
+    /// Any I/O error from the standard library that's not part of this list.
+    ///
+    /// Errors that are `Uncategorized` now may move to a different or a new
+    /// [`ErrorKind`] variant in the future. It is not recommended to match
+    /// an error against `Uncategorized`; use a wildcard match (`_`) instead.
+    #[doc(hidden)]
+    Uncategorized,
 }
 
 impl ErrorKind {
@@ -178,6 +186,7 @@ impl ErrorKind {
             ErrorKind::Other => "other os error",
             ErrorKind::UnexpectedEof => "unexpected end of file",
             ErrorKind::Unsupported => "unsupported I/O error",
+            ErrorKind::Uncategorized => "uncategorized",
         }
     }
 }
@@ -218,7 +227,7 @@ impl From<std::io::ErrorKind> for ErrorKind {
             std::io::ErrorKind::Other => ErrorKind::Other,
             std::io::ErrorKind::UnexpectedEof => ErrorKind::UnexpectedEof,
             std::io::ErrorKind::Unsupported => ErrorKind::Unsupported,
-            _ => ErrorKind::Unsupported,
+            _ => ErrorKind::Uncategorized,
         }
     }
 }

--- a/src/io/error.rs
+++ b/src/io/error.rs
@@ -152,13 +152,8 @@ pub enum ErrorKind {
     /// read.
     UnexpectedEof,
 
-    /// Any I/O error from the standard library that's not part of this list.
-    ///
-    /// Errors that are `Uncategorized` now may move to a different or a new
-    /// [`ErrorKind`] variant in the future. It is not recommended to match
-    /// an error against `Uncategorized`; use a wildcard match (`_`) instead.
-    #[doc(hidden)]
-    Uncategorized,
+    /// Unsupported I/O error
+    Unsupported,
 }
 
 impl ErrorKind {
@@ -182,7 +177,7 @@ impl ErrorKind {
             ErrorKind::Interrupted => "operation interrupted",
             ErrorKind::Other => "other os error",
             ErrorKind::UnexpectedEof => "unexpected end of file",
-            ErrorKind::Uncategorized => "uncategorized",
+            ErrorKind::Unsupported => "unsupported I/O error",
         }
     }
 }
@@ -222,7 +217,8 @@ impl From<std::io::ErrorKind> for ErrorKind {
             std::io::ErrorKind::Interrupted => ErrorKind::Interrupted,
             std::io::ErrorKind::Other => ErrorKind::Other,
             std::io::ErrorKind::UnexpectedEof => ErrorKind::UnexpectedEof,
-            _ => ErrorKind::Uncategorized,
+            std::io::ErrorKind::Unsupported => ErrorKind::Unsupported,
+            _ => ErrorKind::Unsupported,
         }
     }
 }


### PR DESCRIPTION
`ErrorKind::Unsupported` was removed in c22ddb0778ba9475df474ea6210a61073d1b069c due to it only being available in Rust 1.53.0. That's older than the current MSRV, so we can now revert the patch.

This restores compatibility with [`std::io::ErrorKind::Unsupported`]

[`std::io::ErrorKind::Unsupported`]: https://doc.rust-lang.org/stable/std/io/enum.ErrorKind.html#variant.Unsupported