### PR TITLE
Support io errors with arbitrary payloads in "alloc" mode.

### DIFF
--- a/src/io/error.rs
+++ b/src/io/error.rs
@@ -326,7 +326,7 @@ impl Error {
     /// # Examples
     ///
     /// ```
-    /// use std::io::{Error, ErrorKind};
+    /// use no_std_io2::io::{Error, ErrorKind};
     ///
     /// // errors can be created from strings
     /// let custom_error = Error::new(ErrorKind::Other, "oh no!");
@@ -355,12 +355,13 @@ impl Error {
     /// # Examples
     ///
     /// ```
-    /// use std::io::Error;
+    /// use no_std_io2::io::Error;
     ///
     /// // errors can be created from strings
     /// let custom_error = Error::other("oh no!");
     ///
     /// // errors can also be created from other errors
+    /// #[cfg(feature = "alloc")]
     /// let custom_error2 = Error::other(custom_error);
     /// ```
     #[cfg(not(feature = "alloc"))]
@@ -377,7 +378,7 @@ impl Error {
     /// # Examples
     ///
     /// ```
-    /// use std::io::Error;
+    /// use no_std_io2::io::Error;
     ///
     /// // errors can be created from strings
     /// let custom_error = Error::other("oh no!");
@@ -467,7 +468,7 @@ impl Error {
     /// # Examples
     ///
     /// ```
-    /// use std::io::{Error, ErrorKind};
+    /// use no_std_io2::io::{Error, ErrorKind};
     ///
     /// fn print_error(err: &Error) {
     ///     if let Some(inner_err) = err.get_ref() {
@@ -478,8 +479,6 @@ impl Error {
     /// }
     ///
     /// fn main() {
-    ///     // Will print "No inner error".
-    ///     print_error(&Error::last_os_error());
     ///     // Will print "Inner error: ...".
     ///     print_error(&Error::new(ErrorKind::Other, "oh no!"));
     /// }
@@ -554,7 +553,7 @@ impl Error {
     /// # Examples
     ///
     /// ```
-    /// use std::io::{Error, ErrorKind};
+    /// use no_std_io2::io::{Error, ErrorKind};
     ///
     /// fn print_error(err: Error) {
     ///     if let Some(inner_err) = err.into_inner() {
@@ -565,8 +564,6 @@ impl Error {
     /// }
     ///
     /// fn main() {
-    ///     // Will print "No inner error".
-    ///     print_error(Error::last_os_error());
     ///     // Will print "Inner error: ...".
     ///     print_error(Error::new(ErrorKind::Other, "oh no!"));
     /// }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -449,6 +449,29 @@ fn test_writer_read_from_one_buf() {
     assert_eq!(writer.written, &[1, 1, 2, 2, 3]);
 }
 
+#[test]
+fn test_io_error_other() {
+    let err = io::Error::other("error!");
+    assert_eq!(err.kind(), io::ErrorKind::Other);
+    assert_eq!(err.into_inner().unwrap().to_string(), "error!");
+
+    #[cfg(feature = "alloc")]
+    {
+        let err = io::Error::other(io::Error::other("nested"));
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert_eq!(
+            err.into_inner()
+                .unwrap()
+                .downcast::<io::Error>()
+                .unwrap()
+                .into_inner()
+                .unwrap()
+                .to_string(),
+            "nested"
+        );
+    }
+}
+
 // #[test]
 // fn test_writer_read_from_multiple_bufs() {
 //     let mut writer = test_writer(3, 3);


### PR DESCRIPTION
When "alloc" is enabled, support `io::Error`s with arbitrary payloads using a `Box`, following the standard library's API.

While here, also add support for `io::Error::other`.