### PR TITLE
Add a `rust-veresion` to Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0 OR MIT"
 edition = "2021"
 repository = "https://github.com/wcampbell0x2a/no-std-io2"
 categories = ["no-std"]
+rust-version = "1.81"
 
 [dependencies]
 memchr = { version = "2", default-features = false }


### PR DESCRIPTION
Fixes #12.