### PR TITLE
Add no_std and no_alloc check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,3 +115,17 @@ jobs:
 
       - name: Run fuzz tests -- Write (no_std)
         run: cargo fuzz run -s none fuzz_write -- -runs=10000000
+  test-no-std:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-none
+      - uses: cargo-bins/cargo-binstall@main
+      - name: Install cargo-no-std
+        run: cargo binstall --no-confirm --force cargo-no-std
+      - name: Check no_std
+        run: cargo no-std --no-default-features
+      - name: Check no_std (alloc)
+        run: cargo no-std --no-default-features --alloc --features alloc


### PR DESCRIPTION
I've recently become one of this crate's dependents, so it would be good to be certain that no_std and no_alloc guarantees are kept.