### PR TITLE
Fix issue where Cursors backed with `Vec`s always write to the end.

### DIFF
--- a/src/io/cursor.rs
+++ b/src/io/cursor.rs
@@ -278,7 +278,11 @@ fn vec_write_all(pos: usize, vec: &mut alloc::vec::Vec<u8>, buf: &[u8]) {
     if desired_end > vec.len() {
         vec.resize(desired_end, 0);
     }
-    vec.as_mut_slice()[pos..desired_end].copy_from_slice(buf);
+    // SAFETY: We have just resized the vector to have at least `buf.len()` bytes of valid write space before `vec.len()`,
+    // so we can just write now and don't have to worry about uninitialized bytes or buffer over-runs.
+    unsafe {
+        core::ptr::copy_nonoverlapping(buf.as_ptr(), vec.as_mut_ptr().add(pos), buf.len());
+    }
 }
 
 #[cfg(feature = "alloc")]

--- a/src/io/cursor.rs
+++ b/src/io/cursor.rs
@@ -271,11 +271,29 @@ impl Write for Cursor<&mut [u8]> {
     }
 }
 
+// matching the behaviour of std::io::Cursor<&mut Vec> and std::io::Cursor<Vec>
+#[cfg(feature = "alloc")]
+fn vec_write_all(pos: usize, vec: &mut alloc::vec::Vec<u8>, buf: &[u8]) {
+    let buf_len = buf.len();
+
+    let desired_capacity = pos.saturating_add(buf_len);
+    if desired_capacity > vec.capacity() {
+        vec.reserve(vec.capacity() - desired_capacity);
+        unsafe {
+            vec.as_mut_ptr().add(pos).copy_from(buf.as_ptr(), buf.len());
+            vec.set_len(desired_capacity);
+        }
+    } else {
+        vec.as_mut_slice()[pos..desired_capacity].copy_from_slice(buf);
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl Write for Cursor<&mut alloc::vec::Vec<u8>> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        self.inner.extend_from_slice(buf);
+        vec_write_all(self.pos as usize, self.inner, buf);
+        self.pos += buf.len() as u64;
         Ok(buf.len())
     }
 
@@ -289,7 +307,8 @@ impl Write for Cursor<&mut alloc::vec::Vec<u8>> {
 impl Write for Cursor<alloc::vec::Vec<u8>> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        self.inner.extend_from_slice(buf);
+        vec_write_all(self.pos as usize, &mut self.inner, buf);
+        self.pos += buf.len() as u64;
         Ok(buf.len())
     }
 

--- a/src/io/cursor.rs
+++ b/src/io/cursor.rs
@@ -278,7 +278,8 @@ fn vec_write_all(pos: usize, vec: &mut alloc::vec::Vec<u8>, buf: &[u8]) {
 
     let desired_capacity = pos.saturating_add(buf_len);
     if desired_capacity > vec.capacity() {
-        vec.reserve(vec.capacity() - desired_capacity);
+        vec.reserve(desired_capacity - vec.capacity());
+        // SAFETY: We have reserved enough capacity to hold the new data.
         unsafe {
             vec.as_mut_ptr().add(pos).copy_from(buf.as_ptr(), buf.len());
             vec.set_len(desired_capacity);

--- a/src/io/cursor.rs
+++ b/src/io/cursor.rs
@@ -274,19 +274,11 @@ impl Write for Cursor<&mut [u8]> {
 // matching the behaviour of std::io::Cursor<&mut Vec> and std::io::Cursor<Vec>
 #[cfg(feature = "alloc")]
 fn vec_write_all(pos: usize, vec: &mut alloc::vec::Vec<u8>, buf: &[u8]) {
-    let buf_len = buf.len();
-
-    let desired_capacity = pos.saturating_add(buf_len);
-    if desired_capacity > vec.capacity() {
-        vec.reserve(desired_capacity - vec.capacity());
-        // SAFETY: We have reserved enough capacity to hold the new data.
-        unsafe {
-            vec.as_mut_ptr().add(pos).copy_from(buf.as_ptr(), buf.len());
-            vec.set_len(desired_capacity);
-        }
-    } else {
-        vec.as_mut_slice()[pos..desired_capacity].copy_from_slice(buf);
+    let desired_end = pos.saturating_add(buf.len());
+    if desired_end > vec.len() {
+        vec.resize(desired_end, 0);
     }
+    vec.as_mut_slice()[pos..desired_end].copy_from_slice(buf);
 }
 
 #[cfg(feature = "alloc")]
@@ -341,5 +333,29 @@ mod tests {
         let buf = [0x01, 0x02, 0x03];
         cursor.write(&buf).unwrap();
         assert_eq!(cursor.into_inner().as_slice(), [0x01, 0x02, 0x03]);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn test_vec_reverse_and_write() {
+        let mut buf = alloc::vec![0x01u8, 0x02, 0x03];
+        let mut cursor = Cursor::new(&mut buf);
+        cursor.set_position(0x02);
+        cursor.write(&[0x03, 0x04]).unwrap();
+        cursor.set_position(0);
+        cursor.write(&[0x00, 0x00]).unwrap();
+        drop(cursor);
+        assert_eq!(buf, alloc::vec![0x00, 0x0, 0x03, 0x04]);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn test_vec_write_past_end() {
+        let mut buf = alloc::vec![0x01u8, 0x02, 0x03];
+        let mut cursor = Cursor::new(&mut buf);
+        cursor.set_position(0x04);
+        cursor.write(&[0x05, 0x06]).unwrap();
+        drop(cursor);
+        assert_eq!(buf, alloc::vec![0x01, 0x02, 0x03, 0x00, 0x05, 0x06]);
     }
 }


### PR DESCRIPTION
This copies the standard library's general approach, but keeps it in a one wrapper function.

I was looking for a replacement for core2 given the recent yanking, and found this one.

I had self-rolled a cursor in my private project, but seeing https://github.com/wcampbell0x2a/no-std-io2/issues/23 made me want to fix it in here since it's relatively simple.